### PR TITLE
fix: remove norelease type, add chore and docs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,8 @@ runs:
         types: |
           fix
           feat
-          norelease
+          chore
+          docs
         validateSingleCommit: true
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
our default semantic-release configuration doesn't use "norelease" as a
type, but rather as a scope, so checking for "norelease" as a type is a
bit misleading on what the actual behavior will be.
ref: https://github.com/catalystsquad/release-config-general/blob/90e87288a3c166f464f222a35a6fcb69a92404f4/index.js#L10

additionally, add more common types, such as chore and docs.