### PR TITLE
fix: update dependency on amannn/action-semantic-pull-request to get …

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - uses: amannn/action-semantic-pull-request@v3.4.6
+    - uses: amannn/action-semantic-pull-request@v5
       with:
         types: |
           fix


### PR DESCRIPTION
…off node12 requirements for runners