### PR TITLE
fix: allow build type

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,7 @@ runs:
           feat
           chore
           docs
+          build
         validateSingleCommit: true
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
because that's what the dependency bot does